### PR TITLE
이벤트시트 api 호출 로직 추가

### DIFF
--- a/hooks/queries/eventSheet.ts
+++ b/hooks/queries/eventSheet.ts
@@ -1,0 +1,118 @@
+import {
+  BasicEventSheet,
+  RecurringWeekdaysEventSheet,
+  SpecificDateEventSheet,
+} from '@/types/eventSheet'
+import { useMutation, useQuery } from '@tanstack/react-query'
+
+// 이벤트 시트 조회 API
+const getEventSheet = async (eventSheetCode: string, region: string) => {
+  const response = await fetch(
+    `/v1/event-sheet/${eventSheetCode}?region=${region}`,
+    {
+      method: 'GET',
+    }
+  )
+  if (!response.ok) {
+    throw new Error('Network response was not ok')
+  }
+  return response.json()
+}
+
+// 기본 이벤트 시트 생성 API
+const createEventSheet = async (eventSheet: BasicEventSheet) => {
+  const response = await fetch('/v1/event-sheet', {
+    method: 'POST',
+    body: JSON.stringify(eventSheet),
+  })
+  if (!response.ok) {
+    throw new Error('Network response was not ok')
+  }
+  return response.json()
+}
+
+// 특정 날짜 기반 이벤트 시트 생성 API
+const createSpecificDateEventSheet = async (
+  eventSheet: SpecificDateEventSheet
+) => {
+  const response = await fetch('/v1/event-sheet/specific-dates', {
+    method: 'POST',
+    body: JSON.stringify(eventSheet),
+  })
+  if (!response.ok) {
+    throw new Error('Network response was not ok')
+  }
+  return response.json()
+}
+
+// 요일 기반 이벤트 시트 생성 API
+const createRecurringWeekdaysEventSheet = async (
+  eventSheet: RecurringWeekdaysEventSheet
+) => {
+  const response = await fetch('/v1/event-sheet/recurring-weekdays', {
+    method: 'POST',
+    body: JSON.stringify(eventSheet),
+  })
+  if (!response.ok) {
+    throw new Error('Network response was not ok')
+  }
+  return response.json()
+}
+
+// 이벤트 시트 조회 쿼리 훅
+export const useEventSheetQuery = (eventSheetCode: string, region: string) => {
+  return useQuery({
+    queryKey: ['eventSheet', eventSheetCode],
+    queryFn: () => getEventSheet(eventSheetCode, region),
+  })
+}
+
+// 기본 이벤트 시트 생성 쿼리 훅
+const useCreateEventSheetMutation = () => {
+  return useMutation({
+    mutationKey: ['eventSheet'],
+    mutationFn: (eventSheet: BasicEventSheet) => createEventSheet(eventSheet),
+    onSuccess: () => {
+      // 이벤트 시트 생성 성공 시 처리
+      console.log('이벤트 시트 생성 성공')
+    },
+    onError: () => {
+      // 이벤트 시트 생성 실패 시 처리
+      console.log('이벤트 시트 생성 실패')
+    },
+  })
+}
+
+// 특정 날짜 기반 이벤트 생성 쿼리 훅
+const useSpecificDateEventSheetMutation = () => {
+  return useMutation({
+    mutationKey: ['specificDateEventSheet'],
+    mutationFn: (eventSheet: SpecificDateEventSheet) =>
+      createSpecificDateEventSheet(eventSheet),
+    onSuccess: () => {
+      // 이벤트 시트 생성 성공 시 처리
+      console.log('이벤트 시트 생성 성공')
+    },
+    onError: () => {
+      // 이벤트 시트 생성 실패 시 처리
+      console.log('이벤트 시트 생성 실패')
+    },
+  })
+}
+
+// 요일 기반 이벤트 생성 쿼리 훅
+const useRecurringWeekdaysEventSheetMutation = () => {
+  return useMutation({
+    mutationKey: ['recurringWeekdaysEventSheet'],
+    mutationFn: (eventSheet: RecurringWeekdaysEventSheet) =>
+      createRecurringWeekdaysEventSheet(eventSheet),
+    onSuccess: () => {
+      // 이벤트 시트 생성 성공 시 처리
+      console.log('이벤트 시트 생성 성공')
+    },
+    onError: () => {
+      // 이벤트 시트 생성 실패 시 처리
+      console.log('이벤트 시트 생성 실패')
+    },
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "meetgom-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.66.0",
         "date-fns": "^3.6.0",
         "fs-monkey": "^1.0.6",
         "hast-util-is-element": "^3.0.0",
@@ -4666,6 +4667,30 @@
       "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.66.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.66.0.tgz",
+      "integrity": "sha512-J+JeBtthiKxrpzUu7rfIPDzhscXF2p5zE/hVdrqkACBP8Yu0M96mwJ5m/8cPPYQE9aRNvXztXHlNwIh4FEeMZw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.66.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.66.0.tgz",
+      "integrity": "sha512-z3sYixFQJe8hndFnXgWu7C79ctL+pI0KAelYyW+khaNJ1m22lWrhJU2QrsTcRKMuVPtoZvfBYrTStIdKo+x0Xw==",
+      "dependencies": {
+        "@tanstack/query-core": "5.66.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.66.0",
     "date-fns": "^3.6.0",
     "fs-monkey": "^1.0.6",
     "hast-util-is-element": "^3.0.0",

--- a/types/eventSheet.ts
+++ b/types/eventSheet.ts
@@ -1,0 +1,32 @@
+export interface EventSheetTimeSlot {
+  date: string
+  startTime: string
+  endTime: string
+}
+
+export interface EventSheet {
+  name: string
+  description: string
+  eventSheetType: 'RECURRING_WEEKDAYS' | 'SPECIFIC_DATES'
+  timeZone: string
+  pinCode: string
+  activeStartDateTime: string
+  activeEndDateTime: string
+  manualActive: boolean
+}
+
+export type BasicEventSheet = EventSheet & {
+  eventSheetTimeSlots: EventSheetTimeSlot[]
+}
+
+export type SpecificDateEventSheet = EventSheet & {
+  specificDates: string[]
+  startTime: string
+  endTime: string
+}
+
+export type RecurringWeekdaysEventSheet = EventSheet & {
+  recurringWeekdays: string[]
+  startTime: string
+  endTime: string
+}


### PR DESCRIPTION
## 변경 사항 설명

<!-- 이 PR에서 변경한 내용을 간단히 설명해 주세요 -->
- tanstack query 를 설치했습니다.
- 이벤트시트 생성을 위한 api 호출 함수와 tanstack query 훅을 구현했습니다.

## 변경 유형

- [ ] 버그 수정
- [X] 새로운 기능
- [ ] 코드 스타일 변경
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 업데이트
- [ ] 기타 (설명해 주세요):

## 스크린샷

<!-- UI 변경이 있다면 스크린샷을 추가해 주세요 -->

## 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
- hooks/queries 폴더 안에 API 함수와 Tanstack query 훅을 구현해놓았습니다.
- type 파일은 types 폴더 안에 구현했어요.
- 각 훅에 대한 설명:
useEventSheetQuery: 이벤트 시트 데이터를 조회하는 쿼리 훅입니다.
useCreateEventSheetMutation: 기본 이벤트 시트를 생성하는 뮤테이션 훅입니다.
useSpecificDateEventSheetMutation: 특정 날짜 기반 이벤트 시트를 생성하는 뮤테이션 훅입니다.
useRecurringWeekdaysEventSheetMutation: 요일 기반 이벤트 시트를 생성하는 뮤테이션 훅입니다.

- 문제가 있다면 알려주세요.

## 관련 이슈

<!-- 관련된 이슈 번호가 있다면 여기에 링크해 주세요 (예: #123) -->

